### PR TITLE
Intel & Bounties

### DIFF
--- a/Saved/KOTH/ServerSettings.json
+++ b/Saved/KOTH/ServerSettings.json
@@ -346,6 +346,30 @@
         "description": "In the presence of royalty, some find glory not in battle... but in boots to kiss.",
         "texture": "/Game/UI/RadialMenu/RadialMenutextures/Icons/Markers/Enemy/Misc/map_mine.map_mine",
         "display reward": true
+      },
+	  {
+        "name": "Zone Intel",
+        "xp": 100,
+        "$": 100,
+        "description": "This is the last time you're telling the story of what happened in there.",
+        "texture": "/Game/UI/RadialMenu/RadialMenutextures/Icons/Markers/Enemy/Misc/map_mine.map_mine",
+        "display reward": true
+      },
+	  {
+        "name": "Prio Intel",
+        "xp": 200,
+        "$": 200,
+        "description": "How the fuck did you get out of there?",
+        "texture": "/Game/UI/RadialMenu/RadialMenutextures/Icons/Markers/Enemy/Misc/map_mine.map_mine",
+        "display reward": true
+      },
+	  {
+        "name": "Bounty",
+        "xp": -1,
+        "$": -1,
+        "description": "Damn you smoked his ass. I owe you one.",
+        "texture": "/Game/UI/RadialMenu/RadialMenutextures/Icons/Markers/Enemy/Misc/map_mine.map_mine",
+        "display reward": true
       }
     ]
   },
@@ -4138,6 +4162,15 @@
           "texture": "/Game/UI/Widgets/Menu_Main/Icons/mainmenu_star.mainmenu_star",
           "material": "None",
           "unlock level": 35,
+          "unlock items": [],
+          "prestige": 0
+        },
+		{
+          "name": "Got Milk?",
+          "description": "Strong bones, faster pulls. Pop your chute lower and slam into the Zone before the rest even clear the clouds.",
+          "texture": "/Game/UI/RadialMenu/RadialMenuTextures/Icons/Markers/CommandMarker/map_commandmarker_reinforcement.map_commandmarker_reinforcement",
+          "material": "None",
+          "unlock level": 40,
           "unlock items": [],
           "prestige": 0
         },
@@ -7980,6 +8013,15 @@
           "texture": "/Game/UI/Widgets/Menu_Main/Icons/mainmenu_star.mainmenu_star",
           "material": "None",
           "unlock level": 35,
+          "unlock items": [],
+          "prestige": 0
+        },
+		{
+          "name": "Got Milk?",
+          "description": "Strong bones, faster pulls. Pop your chute lower and slam into the Zone before the rest even clear the clouds.",
+          "texture": "/Game/UI/RadialMenu/RadialMenuTextures/Icons/Markers/CommandMarker/map_commandmarker_reinforcement.map_commandmarker_reinforcement",
+          "material": "None",
+          "unlock level": 40,
           "unlock items": [],
           "prestige": 0
         },
@@ -12062,6 +12104,15 @@
           "texture": "/Game/UI/Widgets/Menu_Main/Icons/mainmenu_star.mainmenu_star",
           "material": "None",
           "unlock level": 35,
+          "unlock items": [],
+          "prestige": 0
+        },
+		{
+          "name": "Got Milk?",
+          "description": "Strong bones, faster pulls. Pop your chute lower and slam into the Zone before the rest even clear the clouds.",
+          "texture": "/Game/UI/RadialMenu/RadialMenuTextures/Icons/Markers/CommandMarker/map_commandmarker_reinforcement.map_commandmarker_reinforcement",
+          "material": "None",
+          "unlock level": 40,
           "unlock items": [],
           "prestige": 0
         },


### PR DESCRIPTION
Bounties / Intel:
Earn Intel by capturing the zone or prio. The more you rack up, the higher your bonus. Once your bonus passes $100, you’ll be marked with a bounty. While under bounty, enemies are notified and can steal your bonus if they take you down. To clear it, make it back to Main and interact with the “?” Welcome Store, or just exit a vehicle there for command to clear your bounty automatically. Survive the trip and you’ll not only keep your bonus but also score extra cash and XP for shaking the bounty and bringing new intel to command. 

New Perk: Got Milk?
Strong bones, faster pulls. Pop your chute lower and slam into the Zone before the rest even clear the clouds.